### PR TITLE
Projects based on Symfony Flex require `make`

### DIFF
--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:7-alpine
 
-RUN apk --no-cache add curl git subversion openssh openssl mercurial tini bash zlib-dev
+RUN apk --no-cache add curl git subversion openssh openssl make mercurial tini bash zlib-dev
 
 RUN echo "memory_limit=-1" > "$PHP_INI_DIR/conf.d/memory-limit.ini" \
  && echo "date.timezone=${PHP_TIMEZONE:-UTC}" > "$PHP_INI_DIR/conf.d/date_timezone.ini"


### PR DESCRIPTION
When creating a project using symfony/skeleton an error occurs when make is called.

```
$ composer create-project symfony/skeleton flex-test
Installing symfony/skeleton (v3.3.5)
  - Installing symfony/skeleton (v3.3.5): Loading from cache
Created project in flex-test
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 24 installs, 0 updates, 0 removals
  - Installing symfony/flex (v1.0.30): Loading from cache
  - Installing psr/log (1.0.2): Loading from cache
  - Installing symfony/debug (v3.3.10): Loading from cache
  - Installing symfony/polyfill-mbstring (v1.6.0): Loading from cache
  - Installing symfony/console (v3.3.10): Loading from cache
  - Installing symfony/stopwatch (v3.3.10): Loading from cache
  - Installing symfony/routing (v3.3.10): Loading from cache
  - Installing symfony/http-foundation (v3.3.10): Loading from cache
  - Installing symfony/event-dispatcher (v3.3.10): Loading from cache
  - Installing symfony/http-kernel (v3.3.10): Loading from cache
  - Installing symfony/finder (v3.3.10): Loading from cache
  - Installing symfony/filesystem (v3.3.10): Loading from cache
  - Installing psr/container (1.0.0): Loading from cache
  - Installing symfony/dependency-injection (v3.3.10): Loading from cache
  - Installing symfony/config (v3.3.10): Loading from cache
  - Installing symfony/class-loader (v3.3.10): Loading from cache
  - Installing symfony/polyfill-apcu (v1.6.0): Loading from cache
  - Installing psr/simple-cache (1.0.0): Loading from cache
  - Installing psr/cache (1.0.1): Loading from cache
  - Installing symfony/cache (v3.3.10): Loading from cache
  - Installing doctrine/cache (v1.7.1): Loading from cache
  - Installing symfony/framework-bundle (v3.3.10): Loading from cache
  - Installing symfony/yaml (v3.3.10): Loading from cache
  - Installing symfony/dotenv (v3.3.10): Loading from cache
Writing lock file
Generating autoload files
Symfony operations: 4 recipes
  - Configuring symfony/flex (1.0): From github.com/symfony/recipes:master
  - Configuring symfony/console (3.3): From github.com/symfony/recipes:master
  - Configuring symfony/routing (3.3): From github.com/symfony/recipes:master
  - Configuring symfony/framework-bundle (3.3): From github.com/symfony/recipes:master
Executing script make cache-warmup [KO]
 [KO]
Script make cache-warmup returned with error code 127
!!  sh: make: not found
!!
!!
``` 